### PR TITLE
Optimization of implementation of "assert-dead"

### DIFF
--- a/siodp.h
+++ b/siodp.h
@@ -110,7 +110,7 @@ void gc_for_newcell(void);
 void gc_mark_and_sweep(void);
 void gc_ms_stats_start(void);
 void gc_ms_stats_end(void);
-void gc_mark(LISP ptr, LISP** traced_objs, long traced_objs_tail_index);
+void gc_mark(LISP ptr, long traced_objs_tail_index);
 void mark_protected_registers(void);
 void mark_locations(LISP *start,LISP *end);
 void mark_locations_array(LISP *x,long n);

--- a/sliba.c
+++ b/sliba.c
@@ -76,7 +76,7 @@ LISP array_gc_mark(LISP ptr) {
     long j;
     if TYPEP(ptr, tc_lisp_array)
         for (j = 0; j < ptr->storage_as.lisp_array.dim; ++j)
-            gc_mark(ptr->storage_as.lisp_array.data[j], NULL, -1L);
+            gc_mark(ptr->storage_as.lisp_array.data[j], -1L);
     return (NIL);
 }
 

--- a/trace.c
+++ b/trace.c
@@ -107,7 +107,7 @@ static void ct_gc_scan(LISP ptr) {
 }
 
 static LISP ct_gc_mark(LISP ptr) {
-    gc_mark(ptr->storage_as.closure.code, NULL, -1L);
+    gc_mark(ptr->storage_as.closure.code, -1L);
     return (ptr->storage_as.closure.env);
 }
 


### PR DESCRIPTION
优化内存使用，去掉了不必要的空间分配，至始至终都反复使用同一个指针数组“traced_objs”来记录GC Mark过程中被标记的对象路径